### PR TITLE
 AOP를 통한 레이어 단위 로깅 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 }
 

--- a/src/main/java/com/example/springelkexceptiontracking/aspect/LoggingAspect.java
+++ b/src/main/java/com/example/springelkexceptiontracking/aspect/LoggingAspect.java
@@ -1,0 +1,68 @@
+package com.example.springelkexceptiontracking.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.slf4j.MDC;
+
+import java.util.UUID;
+
+@Slf4j
+@Aspect
+@Component
+public class LoggingAspect {
+
+    private static final String REQUEST_ID = "requestId";
+
+    @Around("execution(* com.example.springelkexceptiontracking.controller..*(..))")
+    public Object logControllerExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        return logExecution(joinPoint, "Controller");
+    }
+
+    @Around("execution(* com.example.springelkexceptiontracking.service..*(..))")
+    public Object logServiceExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        return logExecution(joinPoint, "Service");
+    }
+
+    @Around("execution(* com.example.springelkexceptiontracking.repository..*(..))")
+    public Object logRepositoryExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        return logExecution(joinPoint, "Repository");
+    }
+
+    private Object logExecution(ProceedingJoinPoint joinPoint, String layer) throws Throwable {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(REQUEST_ID, requestId);
+
+        // Log method start
+        String methodName = joinPoint.getSignature().toShortString();
+        Object[] args = joinPoint.getArgs();
+        log.info("RequestID: {} | {} execution started: {} with arguments = {}", requestId, layer, methodName, args);
+
+        long startTime = System.currentTimeMillis();
+        Object result = joinPoint.proceed();
+        long duration = System.currentTimeMillis() - startTime;
+
+        // Log method end with execution time
+        log.info("RequestID: {} | {} execution finished: {} with result = {} - Duration: {} ms",
+                requestId, layer, methodName, result, duration);
+
+        MDC.remove(REQUEST_ID);
+        return result;
+    }
+
+    @Around("execution(* com.example.springelkexceptiontracking..*(..))")
+    public Object logErrors(ProceedingJoinPoint joinPoint) throws Throwable {
+        String requestId = UUID.randomUUID().toString();
+        MDC.put(REQUEST_ID, requestId);
+        try {
+            return joinPoint.proceed();
+        } catch (Exception e) {
+            log.error("RequestID: {} | Error in method: {} | Message: {} | StackTrace: {}", requestId, joinPoint.getSignature(), e.getMessage(), e);
+            throw e;
+        } finally {
+            MDC.remove(REQUEST_ID);
+        }
+    }
+}


### PR DESCRIPTION
## 연결 된 이슈
- close #1 
- close #2 

이번 PR은 `springelkexceptiontracking` 프로젝트에서 Controller, Service, Repository 계층의 메소드 실행을 추적하는 로깅 Aspect를 추가한다. 이 Aspect는 메소드 실행 시작과 종료를 기록하며, 실행 시간을 함께 로그에 출력한다. 또한, 에러 발생 시 중앙 집중식 로깅을 제공하고 각 요청마다 고유한 `requestId`를 사용하여 디버깅과 추적을 용이하게 한다.

**주요 기능:**
- **실행 시작과 종료 로깅:** Controller, Service, Repository 계층의 메소드 실행 시, 메소드 시작, 인수, 결과 및 실행 시간을 로그로 기록한다.
- **오류 처리:** 메소드 실행 중 발생하는 예외를 잡아내어 스택 트레이스와 함께 로그로 기록한다. 또한, 고유한 `requestId`를 사용하여 오류를 추적한다.
- **MDC (Mapped Diagnostic Context) 사용:** `MDC`를 사용해 각 로그에 고유한 `requestId`를 첨부하여, 서로 다른 계층에서의 로그를 쉽게 연관시킬 수 있다.
- **계층별 로깅:** Controller, Service, Repository 각 계층에 대해 개별적인 `@Around` 어드바이스 메소드를 두어 코드의 명확성과 관심사 분리를 유지한다.


이렇게 수정된 설명을 사용하시면 됩니다!